### PR TITLE
Rename gradle functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ In order to submit your app to the App Store, you will need to eventually add th
 
 ### Configure Android
 
-- Add `apply from: '../node_modules/react-native-unimodules/gradle.groovy'` and then `includeUnimodules()` to the top of  `android/settings.gradle`
-- Add `apply from: '../../node_modules/react-native-unimodules/gradle.groovy'` anywhere in `android/app/build.gradle` and then `useUnimodules()` inside `dependencies {}` block.
-- If you need to customize the path to node_modules, for example because you are using yarn workspaces, then you can pass in a param `modulesPaths` for both of these functions: `includeUnimodules([modulesPaths: ['./path/to/node_modules']])`, `useUnimodules([modulesPaths: ['./path/to/node_modules']])`
+- Add `apply from: '../node_modules/react-native-unimodules/gradle.groovy'` and then `includeUnimoduleProjects()` to the top of  `android/settings.gradle`
+- Add `apply from: '../../node_modules/react-native-unimodules/gradle.groovy'` anywhere in `android/app/build.gradle` and then `addUnimoduleDependencies()` inside `dependencies {}` block.
+- If you need to customize the path to node_modules, for example because you are using yarn workspaces, then you can pass in a param `modulesPaths` for both of these functions: `includeUnimoduleProjects([modulesPaths: ['./path/to/node_modules']])`, `addUnimoduleProjects([modulesPaths: ['./path/to/node_modules']])`
 - Update `minSdkVersion` in `android/build.gradle` to 21
 - Update your `MainApplication.java` to according to [this diff](https://gist.github.com/brentvatne/eb4606e39d5d5e6a764c16acde82198a/revisions#diff-a2e7ff8a82f1c4be06f8b8163f2afefa).
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ In order to submit your app to the App Store, you will need to eventually add th
 
 ### Configure Android
 
-- Add `apply from: '../node_modules/react-native-unimodules/gradle.groovy'` and then `includeUnimoduleProjects()` to the top of  `android/settings.gradle`
-- Add `apply from: '../../node_modules/react-native-unimodules/gradle.groovy'` anywhere in `android/app/build.gradle` and then `addUnimoduleDependencies()` inside `dependencies {}` block.
-- If you need to customize the path to node_modules, for example because you are using yarn workspaces, then you can pass in a param `modulesPaths` for both of these functions: `includeUnimoduleProjects([modulesPaths: ['./path/to/node_modules']])`, `addUnimoduleProjects([modulesPaths: ['./path/to/node_modules']])`
+- Add `apply from: '../node_modules/react-native-unimodules/gradle.groovy'` and then `includeUnimodulesProjects()` to the top of  `android/settings.gradle`
+- Add `apply from: '../../node_modules/react-native-unimodules/gradle.groovy'` anywhere in `android/app/build.gradle` and then `addUnimodulesDependencies()` inside `dependencies {}` block.
+- If you need to customize the path to node_modules, for example because you are using yarn workspaces, then you can pass in a param `modulesPaths` for both of these functions: `includeUnimodulesProjects([modulesPaths: ['./path/to/node_modules']])`, `addUnimodulesDependencies([modulesPaths: ['./path/to/node_modules']])`
+- You can also customize the configuration of the unimodules dependencies (the default is `implementation`, if you're using Gradle older than 3.0, you will need to set `configuration: "compile"` in `addUnimodulesDependencies`, like: `addUnimodulesDependencies([configuration: "compile"])`)
 - Update `minSdkVersion` in `android/build.gradle` to 21
 - Update your `MainApplication.java` to according to [this diff](https://gist.github.com/brentvatne/eb4606e39d5d5e6a764c16acde82198a/revisions#diff-a2e7ff8a82f1c4be06f8b8163f2afefa).
 

--- a/gradle.groovy
+++ b/gradle.groovy
@@ -62,10 +62,17 @@ class Colors {
   static final String MAGENTA = "\u001B[35m"
 }
 
-ext.useUnimodules = { Map customOptions = [:] ->
+ext.addUnimoduleDependencies = { Map customOptions = [:] ->
+  if (!(new File(project.rootProject.projectDir.parentFile, 'package.json').exists())) {
+    // There's no package.json
+    throw new GradleException(
+      "'addUnimoduleDependencies()' used in a project that doesn't seem to be a React Native project."
+    )
+  }
+
   def options = [
     modulesPaths: ['../../node_modules'],
-    configuration: 'unimodule',
+    configuration: 'implementation',
     target: 'react-native',
     exclude: [],
   ] << customOptions
@@ -81,12 +88,8 @@ ext.useUnimodules = { Map customOptions = [:] ->
     for (unimodule in unimodules) {
       println ' ' + Colors.GREEN + unimodule.name + Colors.YELLOW + '@' + Colors.RED + unimodule.version + Colors.NORMAL + ' from ' + Colors.MAGENTA + unimodule.directory + Colors.NORMAL
 
-      if (options.configuration == 'unimodule') {
-        expendency(unimodule.name)
-      } else {
-        Object dependency = project.project(':' + unimodule.name)
-        project.dependencies.add(options.configuration, dependency, null)
-      }
+      Object dependency = project.project(':' + unimodule.name)
+      project.dependencies.add(options.configuration, dependency, null)
     }
 
     if (duplicates.size() > 0) {
@@ -104,7 +107,7 @@ ext.useUnimodules = { Map customOptions = [:] ->
   }
 }
 
-ext.includeUnimodules = { Map customOptions = [:] ->
+ext.includeUnimoduleProjects = { Map customOptions = [:] ->
   def options = [
     modulesPaths: ['../../node_modules'],
     target: 'react-native',
@@ -120,22 +123,4 @@ ext.includeUnimodules = { Map customOptions = [:] ->
     include ":${unimodule.name}"
     project(":${unimodule.name}").projectDir = new File(unimodule.directory, subdirectory)
   }
-}
-
-ext.unimodule = { String dep, Closure closure = null ->
-  Object dependency = null
-
-  if (new File(project.rootProject.projectDir.parentFile, 'package.json').exists()) {
-    // Parent directory of the android project has package.json -- probably React Native
-    dependency = project.project(":$dep")
-  } else {
-    // There's no package.json and no pubspec.yaml
-    throw new GradleException(
-      "'unimodules-core.gradle' used in a project that seems to be neither a Flutter nor a React Native project."
-    )
-  }
-
-  String configurationName = project.configurations.findByName("implementation") ? "implementation" : "compile"
-
-  project.dependencies.add(configurationName, dependency, closure)
 }

--- a/gradle.groovy
+++ b/gradle.groovy
@@ -62,11 +62,11 @@ class Colors {
   static final String MAGENTA = "\u001B[35m"
 }
 
-ext.addUnimoduleDependencies = { Map customOptions = [:] ->
+ext.addUnimodulesDependencies = { Map customOptions = [:] ->
   if (!(new File(project.rootProject.projectDir.parentFile, 'package.json').exists())) {
     // There's no package.json
     throw new GradleException(
-      "'addUnimoduleDependencies()' used in a project that doesn't seem to be a React Native project."
+      "'addUnimodulesDependencies()' is being used in a project that doesn't seem to be a React Native project."
     )
   }
 
@@ -107,7 +107,7 @@ ext.addUnimoduleDependencies = { Map customOptions = [:] ->
   }
 }
 
-ext.includeUnimoduleProjects = { Map customOptions = [:] ->
+ext.includeUnimodulesProjects = { Map customOptions = [:] ->
   def options = [
     modulesPaths: ['../../node_modules'],
     target: 'react-native',


### PR DESCRIPTION
Renamed gradle helpers to make them more clear what they do 🙂 

`useUnimodules` -> `addUnimoduleDependencies`
`includeUnimodules` -> `includeUnimoduleProjects`