### PR TITLE
Add TypeScript libdef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+import { Asset } from 'expo-asset'
+import Constants from 'expo-constants'
+import * as FileSystem from 'expo-file-system'
+import * as Permissions from 'expo-permissions'
+
+export {
+  Asset,
+  Constants,
+  FileSystem,
+  Permissions
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "",
   "main": "index.js",
+  "types": "index.d.ts",
   "private": false,
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",


### PR DESCRIPTION
It seems like the individual unimodules already had library definitions, so I just added a simple libdef which reexported those types. Seems to have fixed the TS issues I had when trying to import stuff from `react-native-unimodules`.