### PR TITLE
add optional modules 'expo-face-detector' and 'expo-payments-stripe' to exclude list

### DIFF
--- a/cocoapods.rb
+++ b/cocoapods.rb
@@ -6,7 +6,7 @@ def use_unimodules!(custom_options = {})
   options = {
     modules_paths: ['../node_modules'],
     target: 'react-native',
-    exclude: [],
+    exclude: ['expo-face-detector', 'expo-payments-stripe'],
   }.deep_merge(custom_options)
 
   modules_paths = options.fetch(:modules_paths)


### PR DESCRIPTION
Add ```expo-face-detector``` and ```expo-payments-stripe``` to the exclude list,  as they are optional modules  mentioned in the [doc](https://docs.expo.io/versions/v33.0.0/expokit/universal-modules-and-expokit/)

fix:
https://github.com/expo/expo/issues/4502
Temp fix:
https://github.com/expo/expo/issues/4493
https://github.com/expo/expo/issues/3888
