### PR TITLE
Import VersionNumber for newer versions of gradle

### DIFF
--- a/gradle.groovy
+++ b/gradle.groovy
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import org.gradle.util.VersionNumber
 
 import java.util.regex.Pattern
 


### PR DESCRIPTION
As per #50, this is required in newer versions of gradle.
It would be good if someone using an older version could test that it's backwards compatible.