### PR TITLE
adds missing import

### DIFF
--- a/gradle.groovy
+++ b/gradle.groovy
@@ -2,6 +2,8 @@ import groovy.json.JsonSlurper
 
 import java.util.regex.Pattern
 
+import org.gradle.util.VersionNumber
+
 class Unimodule {
   String name
   List platforms


### PR DESCRIPTION
I got build error missing class `VersionNumber`, adding the import `import org.gradle.util.VersionNumber` seems to fix it.