### PR TITLE
Fix `pod install --deployment` failing due to pathname object being used instead of a string

### DIFF
--- a/cocoapods.rb
+++ b/cocoapods.rb
@@ -70,7 +70,7 @@ def use_unimodules!(custom_options = {})
 
       puts " #{green unimodule[:name]}#{cyan "@"}#{magenta unimodule[:version]} from #{blue podspec_directory}"
 
-      pod_options = flags.merge({ path: podspec_directory })
+      pod_options = flags.merge({ path: podspec_directory.to_s })
 
       pod "#{pod_name}", pod_options
     }


### PR DESCRIPTION
# Why

Fixes #91 

# How

Issue was due to Pathname object being used in the options object of a pod whereas we should have been using a plain string. Added `.to_s` to convert that object to a string.

# Test Plan

Running `pod install --deployment` passes for me and detects no changes just after running `pod install`.
